### PR TITLE
Fix Mobile Styling, Simplify Styles & Improve Accessibility

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -10,7 +10,7 @@
   <body>
     {% include header.html %}
 
-    <main class="page-content">
+    <main>
         {{ content }}
     </main>
 

--- a/_sass/main.scss
+++ b/_sass/main.scss
@@ -18,9 +18,15 @@
 /**
  * Partials
  */
+@import 'partials/backgrounds';
 @import 'partials/footer';
 @import 'partials/header';
 @import 'partials/layout';
+
+/**
+ * Pages
+ */
+@import 'pages/index';
 
 body {
     font-family: 'Roboto', sans-serif;
@@ -28,6 +34,16 @@ body {
     padding: 0;
     margin: 0;
 }
+
+// Override focus styles to be more branded and prominent
+*:focus {
+    outline: none;
+    box-shadow: 0px 0px 0px 3px $orange;
+}
+
+// Make .page-content extend content-width
+.page-content { @extend %content-width; }
+
 
 .btn {
   display: inline-block;
@@ -46,10 +62,6 @@ body {
 }
 .btn:hover {
     background-color: #888888;
-}
-
-a.button {
- text-decoration: none;
 }
 
 .logo-large { height: 130px; }
@@ -75,50 +87,3 @@ a.button {
     text-align: center;
   }
 }
-
-.page-content {
-    @extend %content-width;
-}
-
-.bkgd-1 {
-  background-image: url(/assets/images/mobile-partition-left.png);
-  background-size: cover;
-  background-repeat: no-repeat;
-  margin-left: 0px;
-
-  @media (min-width: $desktop-min-width) {
-    background-image: url(/assets/images/partition-left.png);
-  }
-}
-
-.three-buttons {
-  position: relative;
-  top: -80px;
-  text-align: center;
-
-  .features-img {
-    height: 170px;
-  }
-}
-
-.bkgd-2 {
-  background-image: url(/assets/images/mobile-partition-right.png);
-  background-size: cover;
-  background-repeat: no-repeat;
-  margin-right: 0px;
-
-  @media (min-width: $desktop-min-width) {
-    background-image: url(/assets/images/partition-right.png);
-  }
-}
-
-
-.btn-github {
-    margin-top: 30px;
-}
-
-*:focus {
-    outline: none;
-    box-shadow: 0px 0px 0px 3px $orange;
-}
-

--- a/_sass/main.scss
+++ b/_sass/main.scss
@@ -86,7 +86,7 @@ a.button {
   background-repeat: no-repeat;
   margin-left: 0px;
 
-  @media (min-width: 501px) {
+  @media (min-width: $desktop-min-width) {
     background-image: url(/assets/images/partition-left.png);
   }
 }
@@ -103,12 +103,13 @@ a.button {
 
 .bkgd-2 {
   background-image: url(/assets/images/mobile-partition-right.png);
-  @media (min-width: 501px) {
-    background-image: url(/assets/images/partition-right.png);
-  }
   background-size: cover;
   background-repeat: no-repeat;
   margin-right: 0px;
+
+  @media (min-width: $desktop-min-width) {
+    background-image: url(/assets/images/partition-right.png);
+  }
 }
 
 

--- a/_sass/main.scss
+++ b/_sass/main.scss
@@ -1,5 +1,5 @@
 /**
- * External Resouves
+ * External Resources
  */
 // Google Fonts - Roboto
 @import url('https://fonts.googleapis.com/css?family=Roboto&display=swap');
@@ -42,7 +42,7 @@ body {
   margin-left: auto;
   margin-right: auto;
 }
-.btn:hover { 
+.btn:hover {
     background-color: #888888;
 }
 
@@ -124,7 +124,7 @@ a.button {
   background-repeat: no-repeat;
   width: 130%;
   margin-left: -230px;
-  
+
 }
 
 .three-buttons {

--- a/_sass/main.scss
+++ b/_sass/main.scss
@@ -20,6 +20,7 @@
  */
 @import 'partials/footer';
 @import 'partials/header';
+@import 'partials/layout';
 
 body {
     font-family: 'Roboto', sans-serif;
@@ -29,18 +30,14 @@ body {
 }
 
 .btn {
-  height: 50px;
+  text-align: center;
+  text-decoration: none;
+  padding: 10px 20px;
+  background-color: #464646;
   color: #FFFFFF;
   font-size: 24px;
-  line-height: 28px;
-  display: flex;
-  align-items: center;
-  text-align: center;
-  background-color: #464646;
   border-radius: 9px;
   margin: 0 auto;
-  margin-left: auto;
-  margin-right: auto;
 }
 .btn:hover {
     background-color: #888888;
@@ -50,21 +47,23 @@ a.button {
  text-decoration: none;
 }
 
+.logo-large { height: 130px; }
+.logo-med { height: 90px; }
+
 .hero-banner {
   padding-top: 30px;
   padding-bottom: 30px;
+
   h1 {
     font-style: normal;
     font-weight: 500;
     font-size: 48px;
-    line-height: 56px;
     text-align: center;
   }
   h2 {
     font-style: normal;
     font-weight: 500;
     font-size: 38px;
-    line-height: 56px;
     text-align: center;
   }
 }
@@ -73,77 +72,55 @@ a.button {
     @extend %content-width;
 }
 .section-1 {
-  height: 387px;
   .h1-left {
     display: inline-block;
-    width: 280px;
     text-align: center;
-    transform: translate(190px, 120px);
   }
   .center-btn {
     .btn-learn {
-      width: 170px;
       margin-top: 60px;
-      padding: 0px 0px 0px 24px;
     }
     margin: 0 auto;
-    width: 50%;
     text-align: center;
-    .img-container {
-      height: 130px;
-    }
   }
   .homepage-p-right {
     display: inline-block;
-    height: 100px;
-    width: 330px;
-    float: right;
-    margin: -100px 90px 0px 0px;
   }
   .homepage-p-center {
     display: inline-block;
-    height: 100px;
-    width: 560px;
-    margin: 70px 0px 0px 480px;
+
     p {font-size: 20px;}
   }
   .tool-p-right {
     display: inline-block;
-    height: 100px;
-    float: right;
-    width: 330px;
-    margin: 120px 160px 0px 0px
   }
 }
 .bkgd-1 {
   background-image: url(/assets/images/mobile-partition-left.png);
+  background-size: cover;
+  background-repeat: no-repeat;
+  margin-left: 0px;
+
   @media (min-width: 501px) {
     background-image: url(/assets/images/partition-left.png);
   }
-  background-size: cover;
-  background-repeat: no-repeat;
-  width: 130%;
-  margin-left: -230px;
-
 }
 
 .three-buttons {
+  position: relative;
+  top: -80px;
+  text-align: center;
+
   .features-img {
     height: 170px;
-    margin: -80px 0px 0px 120px;
   }
 }
 .section-2 {
-  height: 240px;
   .h1-right {
     display: inline-block;
-    width: 280px;
-    float: right;
     text-align: center;
-    margin: 30px 100px 0px 0px;
   }
   .center-text {
-    width: 51%;
     text-align: center;
     margin: auto;
     font-size: 20px;
@@ -151,51 +128,31 @@ a.button {
   }
   .p-left {
     display: inline-block;
-    height: 100px;
-    float: left;
-    width: 330px;
-    margin: 60px 0px 0px 60px;
   }
 
   .btn-mission {
-    width: 170px;
     margin-top: 30px;
-    padding: 0px 0px 0px 32px;
   }
 }
 .section-3 {
-  height: 350px;
   .h1-left {
     display: inline-block;
-    width: 280px;
     text-align: center;
-    transform: translate(140px, 80px);
   }
   .p-left {
     display: inline-block;
-    height: 100px;
-    float: left;
-    width: 330px;
-    margin: 100px 0px 0px 130px;
   }
   .p-right {
     display: inline-block;
-    height: 100px;
-    float: right;
-    width: 330px;
-    margin: 100px 300px 0px 0px;
   }
   .center-text {
-    width: 31%;
     text-align: center;
     margin: auto;
     font-size: 20px;
     padding: 110px 310px 50px 0px;
   }
   .btn-team {
-    width: 170px;
     margin-top: 30px;
-    padding: 0px 0px 0px 40px;
   }
 }
 
@@ -206,28 +163,13 @@ a.button {
   }
   background-size: cover;
   background-repeat: no-repeat;
-  width: 130%;
-  margin-right: -230px;
+  margin-right: 0px;
 }
-.section-4 {
-  height: 260px;
-  text-align: center;
-  width: 440px;
-  margin: auto;
 
-  .p-center {
-    width: 121%;
-    text-align: center;
-    margin: auto;
-    font-size: 27px;
-    padding: 50px 0px 100px 0px;
-  }
-}
+
 .btn-github {
-    width: 240px;
     margin-top: 30px;
-    padding: 0px 0px 0px 37px;
-  }
+}
 
 *:focus {
     outline: none;

--- a/_sass/main.scss
+++ b/_sass/main.scss
@@ -30,6 +30,7 @@ body {
 }
 
 .btn {
+  display: inline-block;
   text-align: center;
   text-decoration: none;
   padding: 10px 20px;
@@ -38,6 +39,10 @@ body {
   font-size: 24px;
   border-radius: 9px;
   margin: 0 auto;
+
+  &.-spaced-top {
+    margin-top: 30px;
+  }
 }
 .btn:hover {
     background-color: #888888;
@@ -71,30 +76,7 @@ a.button {
 .page-content {
     @extend %content-width;
 }
-.section-1 {
-  .h1-left {
-    display: inline-block;
-    text-align: center;
-  }
-  .center-btn {
-    .btn-learn {
-      margin-top: 60px;
-    }
-    margin: 0 auto;
-    text-align: center;
-  }
-  .homepage-p-right {
-    display: inline-block;
-  }
-  .homepage-p-center {
-    display: inline-block;
 
-    p {font-size: 20px;}
-  }
-  .tool-p-right {
-    display: inline-block;
-  }
-}
 .bkgd-1 {
   background-image: url(/assets/images/mobile-partition-left.png);
   background-size: cover;
@@ -113,46 +95,6 @@ a.button {
 
   .features-img {
     height: 170px;
-  }
-}
-.section-2 {
-  .h1-right {
-    display: inline-block;
-    text-align: center;
-  }
-  .center-text {
-    text-align: center;
-    margin: auto;
-    font-size: 20px;
-    padding: 30px 0px 50px 0px;
-  }
-  .p-left {
-    display: inline-block;
-  }
-
-  .btn-mission {
-    margin-top: 30px;
-  }
-}
-.section-3 {
-  .h1-left {
-    display: inline-block;
-    text-align: center;
-  }
-  .p-left {
-    display: inline-block;
-  }
-  .p-right {
-    display: inline-block;
-  }
-  .center-text {
-    text-align: center;
-    margin: auto;
-    font-size: 20px;
-    padding: 110px 310px 50px 0px;
-  }
-  .btn-team {
-    margin-top: 30px;
   }
 }
 

--- a/_sass/main.scss
+++ b/_sass/main.scss
@@ -55,19 +55,22 @@ a.button {
 .logo-large { height: 130px; }
 .logo-med { height: 90px; }
 
+.mobile-img {
+  height: 260px;
+  margin: 0 100px;
+}
+
 .hero-banner {
   padding-top: 30px;
   padding-bottom: 30px;
 
   h1 {
-    font-style: normal;
-    font-weight: 500;
+    font-weight: normal;
     font-size: 48px;
     text-align: center;
   }
   h2 {
-    font-style: normal;
-    font-weight: 500;
+    font-weight: normal;
     font-size: 38px;
     text-align: center;
   }

--- a/_sass/pages/_index.scss
+++ b/_sass/pages/_index.scss
@@ -1,0 +1,9 @@
+.three-buttons {
+  position: relative;
+  top: -80px;
+  text-align: center;
+
+  .features-img {
+    height: 170px;
+  }
+}

--- a/_sass/pages/_index.scss
+++ b/_sass/pages/_index.scss
@@ -1,9 +1,15 @@
-.three-buttons {
+.three-btn-cont {
   position: relative;
-  top: -80px;
-  text-align: center;
+  margin-bottom: 40px;
 
-  .features-img {
-    height: 170px;
+  .three-buttons {
+    position: absolute;
+    top: calc(100% - 80px);
+    width: 100%;
+    text-align: center;
+
+    .features-img {
+      height: 170px;
+    }
   }
 }

--- a/_sass/partials/_backgrounds.scss
+++ b/_sass/partials/_backgrounds.scss
@@ -1,0 +1,20 @@
+[class^="bkgd"] {
+  background-size: cover;
+  background-repeat: no-repeat;
+}
+
+.bkgd-1 {
+  background-image: url(/assets/images/mobile-partition-left.png);
+
+  @media (min-width: $desktop-min-width) {
+    background-image: url(/assets/images/partition-left.png);
+  }
+}
+
+.bkgd-2 {
+  background-image: url(/assets/images/mobile-partition-right.png);
+
+  @media (min-width: $desktop-min-width) {
+    background-image: url(/assets/images/partition-right.png);
+  }
+}

--- a/_sass/partials/_header.scss
+++ b/_sass/partials/_header.scss
@@ -47,19 +47,13 @@ header {
         list-style: none;
         display: flex;
         margin: 0;
-        li { 
-          margin: -21px 10px; 
-          &:hover {
-            border-bottom: 17px solid white;
-            
-          }
-        }
+
+        li { margin: 0px 10px; }
     }
 }
 
 // Mobile styling
 @media (max-width: 800px) {
-    main { padding: 0px 15px; }
     header {
         position: relative;
 

--- a/_sass/partials/_layout.scss
+++ b/_sass/partials/_layout.scss
@@ -30,6 +30,10 @@
     }
 }
 
+/**
+ * Center Text - A basic class to center text
+ */
+.center-text { text-align: center; }
 
 /**
  * Desktop Only -  A class for elements that should only show up on desktop

--- a/_sass/partials/_layout.scss
+++ b/_sass/partials/_layout.scss
@@ -1,0 +1,42 @@
+/**
+ * Simple Columns Class - Useful for any basic horizontal columns
+ */
+.simple-cols {
+    display: flex;
+
+    &.-standard {
+        padding: 120px 60px;
+        align-items: center;
+        justify-content: space-evenly;
+    }
+
+    > * { flex: 1; }
+
+    @media (max-width: $mobile-max-width) {
+        flex-direction: column;
+    }
+}
+
+/**
+ * Vertical Columns - A simple class for vertical columns
+ */
+.vertical-cols {
+    display: flex;
+    flex-direction: column;
+
+    &.-center {
+        align-items: center;
+        text-align: center;
+    }
+}
+
+
+/**
+ * Desktop Only -  A class for elements that should only show up on desktop
+ * devices.
+ */
+.dsktp-only {
+    @media (max-width: $mobile-max-width) {
+        display: none;
+    }
+}

--- a/_sass/partials/_layout.scss
+++ b/_sass/partials/_layout.scss
@@ -10,7 +10,8 @@
         justify-content: space-evenly;
     }
 
-    > * { flex: 1; }
+
+    > *:not(.no-grow) { flex: 1; }
 
     @media (max-width: $mobile-max-width) {
         flex-direction: column;
@@ -34,6 +35,14 @@
  * Center Text - A basic class to center text
  */
 .center-text { text-align: center; }
+
+/**
+ * Basic Paragraph - A paragraph with a reasonable max-width and centering
+ */
+.basic-p {
+    max-width: 400px;
+    margin: auto;
+}
 
 /**
  * Desktop Only -  A class for elements that should only show up on desktop

--- a/_sass/partials/_layout.scss
+++ b/_sass/partials/_layout.scss
@@ -10,6 +10,8 @@
         justify-content: space-evenly;
     }
 
+    &.-vertical { flex-direction: column; }
+
 
     > *:not(.no-grow) { flex: 1; }
 
@@ -42,6 +44,11 @@
 .basic-p {
     max-width: 400px;
     margin: auto;
+}
+
+.hero-p {
+    max-width: 600px;
+    font-size: 20px;
 }
 
 /**

--- a/_sass/variables/_spacing.scss
+++ b/_sass/variables/_spacing.scss
@@ -3,3 +3,12 @@
  */
 
 $content-width: 1000px;
+
+
+/**
+ * Media Sizes
+ */
+
+$mobile-max-width: 800px;
+
+$desktop-min-width: 801px;

--- a/css/styles.scss
+++ b/css/styles.scss
@@ -1,4 +1,12 @@
 ---
 ---
 
+/**
+ * This main file is the only SCSS file that is actually compiled down to CSS,
+ * and is creates the final output styles.css that is loaded in the browser.
+ *
+ * DO NOT add anything to this file - add it to one of the SCSS files in /_sass,
+ * and add new SCSS files to main.scss so it gets loaded globally.
+ */
+
 @import 'main';

--- a/in-your-city.html
+++ b/in-your-city.html
@@ -5,7 +5,7 @@ title: In Your City
 
 <div class="hero-banner vertical-cols -center">
   <h1>In Your City</h1>
-  <img src="/assets/images/logo.png" class="logo-med">
+  <img src="/assets/images/logo.png" alt="TransitTalk Logo" class="logo-med">
 </div>
 
 <div class="bkgd-1 simple-cols -vertical -standard">

--- a/in-your-city.html
+++ b/in-your-city.html
@@ -2,33 +2,32 @@
 title: In Your City
 ---
 
-<div class="hero-banner">
+
+<div class="hero-banner vertical-cols -center">
   <h1>In Your City</h1>
-  <img src="/assets/images/logo.png" style="margin-left: 45%;
-    height: 90px;">
+  <img src="/assets/images/logo.png" class="logo-med">
 </div>
-<div class="section-1 bkgd-1">
-  <div class="homepage-p-center">
-    <p><b>Transit Talk</b> is a Ruby on Rails web app based on a data standard called GTFS, which makes storing transit station and route information quite simple.
-    <br><br>
+
+<div class="bkgd-1 simple-cols -vertical -standard">
+  <p class="hero-p">
+    <strong>Transit Talk</strong> is a Ruby on Rails web app based on a data standard called GTFS, which makes storing transit station and route information quite simple.
+  </p>
+
+  <p class="hero-p">
     We’ve tried to create Transit Talk in a way that allows for a coder in any given city to plug in a couple lines of code and immediately have a beautiful, functioning issue reporting system for their local public transit network.
+  </p>
+</div>
+
+<div class="simple-cols -vertical -standard">
+    <a href="http://github.com/TransitTalk/Transit-Talk" class="btn">Visit our Github</a>
+    <p class="hero-p">
+      You don’t need to know what much about GTFS to create a version of <strong>Transit Talk</strong> for your city. Simply head over to out GitHub repository, create a fork of the app, and follow the instructions to build and install an instance of your own!
     </p>
-  </div>
 </div>
-<div class="section-2">
-  <button type="button" class="btn btn-github">Visit our Github</button>
-  <div class="center-text">
-    <p>You don’t need to know what much about GTFS to create a version of <b>Transit Talk</b> for your city. Simply head over to out GitHub repository, create a fork of the app, and follow the instructions to build and install an instance of your own! </p>
-  </div>
-</div>
-   
-</div>
-<div class="section-3 bkgd-2">
-  <div class="center-text">
-    <p>Feel free to join the Chi Hack Night Slack group and chat with us on the #transit-talk channel if you have any questions about setting up your own fork of Transit Talk.
-    </p>
-  </div>
-</div>
-<div class="section-4">
-  
+
+
+<div class="bkgd-2 simple-cols -standard">
+  <p class="hero-p">
+    Feel free to join the Chi Hack Night Slack group and chat with us on the #transit-talk channel if you have any questions about setting up your own fork of Transit Talk.
+  </p>
 </div>

--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@ title: Transit Talk
       <a href="tool.html" class="btn -spaced-top">Learn More</a>
     </div>
   </div>
-  <p>
+  <p class="basic-p">
     <strong>Transit Talk</strong> empowers users to easily submit issue reports for things like cleanliness, accessibility, and delays on public transit, generating real-time, crowdsourced knowledge about a transit system.
   </p>
 </div>
@@ -29,7 +29,8 @@ title: Transit Talk
 
 <div class="simple-cols -standard">
   <div>
-    <p><b>Transit Talk</b> aims to create a transparent record of issues riders encounter, helping riders avoid problems on their commutes in real time while also helping transit agencies become more responsive to the needs of their customers.
+    <p class="basic-p">
+      <strong>Transit Talk</strong> aims to create a transparent record of issues riders encounter, helping riders avoid problems on their commutes in real time while also helping transit agencies become more responsive to the needs of their customers.
     </p>
   </div>
   <div class="center-text">
@@ -43,7 +44,7 @@ title: Transit Talk
     <h2> Our Team </h2>
     <a href="team.html" class="btn">Meet Us</a>
   </div>
-  <p>
+  <p class="basic-p">
     <strong>Transit Talk</strong> is a volunteer-run project that was created at Chi Hack Night, a weekly community event where people of all backgrounds come together to work on civic tech projects.
   </p>
 </div>
@@ -51,7 +52,7 @@ title: Transit Talk
 <div class="vertical-cols -center">
   <h2> Application to Other Cities </h2>
   <a href="http://github.com/TransitTalk/Transit-Talk" class="btn">Visit our Github</a>
-  <p>
+  <p class="basic-p">
     <strong>Transit Talk</strong> is built for more than just Chicago. Through the use of GTFS, a universal data standard used by transit agencies around the world, Transit Talk can be implemented elsewhere easily. Visit our “In Your City” tab to learn more.
   </p>
 </div>

--- a/index.html
+++ b/index.html
@@ -8,15 +8,15 @@ title: Transit Talk
     Public Transit
   </h1>
 </div>
-<div class="section-1 bkgd-1">
+
+<div class="section-1 bkgd-1 simple-cols -standard">
   <div class="h1-left">
     <h1> Our Tool </h1>
   </div>
   <div class="center-btn">
-    <div class="img-container">
-      <img src="/assets/images/logo.png" style="margin-bottom: -53px;
-    height: 130px;">
-    <button onclick='location.href="tool.html"'type="button" class="btn btn-learn">Learn More</button>
+    <div class="vertical-cols -center">
+      <img src="/assets/images/logo.png" class="logo-large">
+      <a href="tool.html" class="btn btn-learn">Learn More</a>
     </div>
   </div>
   <div class="homepage-p-right">
@@ -24,33 +24,36 @@ title: Transit Talk
     </p>
   </div>
 </div>
+
 <div class="three-buttons">
-  <img src="/assets/images/features.png" class="features-img">
+  <img src="/assets/images/features.png" class="features-img dsktp-only">
 </div>
-<div class="section-2">
+
+<div class="section-2 simple-cols -standard">
   <div class="p-left">
     <p><b>Transit Talk</b> aims to create a transparent record of issues riders encounter, helping riders avoid problems on their commutes in real time while also helping transit agencies become more responsive to the needs of their customers.
     </p>
   </div>
   <div class="h1-right">
     <h1> Our Mission </h1>
-    <button onclick='location.href="mission.html"'type="button" class="btn btn-mission">More Info</button>
+    <a href="mission.html" class="btn btn-mission">More Info</a>
   </div>
-   
 </div>
-<div class="section-3 bkgd-2">
+
+<div class="section-3 bkgd-2 simple-cols -standard">
   <div class="h1-left">
     <h1> Our Team </h1>
-    <button onclick='location.href="team.html"'type="button" class="btn btn-team">Meet Us</button>
+    <a href="team.html" class="btn btn-team">Meet Us</a>
   </div>
   <div class="p-right">
     <p><b>Transit Talk</b> is a volunteer-run project that was created at Chi Hack Night, a weekly community event where people of all backgrounds come together to work on civic tech projects.
     </p>
   </div>
 </div>
-<div class="section-4">
+
+<div class="section-4 vertical-cols -center">
   <h1> Application to Other Cities </h1>
-  <a href="http://github.com/TransitTalk/Transit-Talk"><button type="button" class="btn btn-github">Visit our Github</button></a>
+  <a href="http://github.com/TransitTalk/Transit-Talk" class="btn btn-github">Visit our Github</a>
   <p> <b>Transit Talk</b> is built for more than just Chicago. Through the use of GTFS, a universal data standard used by transit agencies around the world, Transit Talk can be implemented elsewhere easily. Visit our “In Your City” tab to learn more.
   </p>
 </div>

--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@ title: Transit Talk
 
   <div class="center-btn">
     <div class="vertical-cols -center">
-      <img src="/assets/images/logo.png" class="logo-large">
+      <img src="/assets/images/logo.png" alt="TransitTalk Logo" class="logo-large">
       <a href="tool.html" class="btn -spaced-top">Learn More</a>
     </div>
   </div>
@@ -23,7 +23,8 @@ title: Transit Talk
   </p>
 
   <div class="three-buttons">
-    <img src="/assets/images/features.png" class="features-img dsktp-only">
+    <img src="/assets/images/features.png" class="features-img dsktp-only"
+      alt="Features - Get Alerts, Report Issues, and Favorite Stops">
   </div>
 </div>
 

--- a/index.html
+++ b/index.html
@@ -52,7 +52,7 @@ title: Transit Talk
 <div class="vertical-cols -center">
   <h2> Application to Other Cities </h2>
   <a href="http://github.com/TransitTalk/Transit-Talk" class="btn">Visit our Github</a>
-  <p class="basic-p">
+  <p class="hero-p">
     <strong>Transit Talk</strong> is built for more than just Chicago. Through the use of GTFS, a universal data standard used by transit agencies around the world, Transit Talk can be implemented elsewhere easily. Visit our “In Your City” tab to learn more.
   </p>
 </div>

--- a/index.html
+++ b/index.html
@@ -9,51 +9,49 @@ title: Transit Talk
   </h1>
 </div>
 
-<div class="section-1 bkgd-1 simple-cols -standard">
-  <div class="h1-left">
-    <h1> Our Tool </h1>
-  </div>
+<div class="bkgd-1 simple-cols -standard">
+  <h2> Our Tool </h2>
+
   <div class="center-btn">
     <div class="vertical-cols -center">
       <img src="/assets/images/logo.png" class="logo-large">
-      <a href="tool.html" class="btn btn-learn">Learn More</a>
+      <a href="tool.html" class="btn -spaced-top">Learn More</a>
     </div>
   </div>
-  <div class="homepage-p-right">
-    <p><b>Transit Talk</b> empowers users to easily submit issue reports for things like cleanliness, accessibility, and delays on public transit, generating real-time, crowdsourced knowledge about a transit system.
-    </p>
-  </div>
+  <p>
+    <strong>Transit Talk</strong> empowers users to easily submit issue reports for things like cleanliness, accessibility, and delays on public transit, generating real-time, crowdsourced knowledge about a transit system.
+  </p>
 </div>
 
 <div class="three-buttons">
   <img src="/assets/images/features.png" class="features-img dsktp-only">
 </div>
 
-<div class="section-2 simple-cols -standard">
-  <div class="p-left">
+<div class="simple-cols -standard">
+  <div>
     <p><b>Transit Talk</b> aims to create a transparent record of issues riders encounter, helping riders avoid problems on their commutes in real time while also helping transit agencies become more responsive to the needs of their customers.
     </p>
   </div>
-  <div class="h1-right">
-    <h1> Our Mission </h1>
-    <a href="mission.html" class="btn btn-mission">More Info</a>
+  <div class="center-text">
+    <h2> Our Mission </h2>
+    <a href="mission.html" class="btn">More Info</a>
   </div>
 </div>
 
-<div class="section-3 bkgd-2 simple-cols -standard">
-  <div class="h1-left">
-    <h1> Our Team </h1>
-    <a href="team.html" class="btn btn-team">Meet Us</a>
+<div class="bkgd-2 simple-cols -standard">
+  <div class="center-text">
+    <h2> Our Team </h2>
+    <a href="team.html" class="btn">Meet Us</a>
   </div>
-  <div class="p-right">
-    <p><b>Transit Talk</b> is a volunteer-run project that was created at Chi Hack Night, a weekly community event where people of all backgrounds come together to work on civic tech projects.
-    </p>
-  </div>
+  <p>
+    <strong>Transit Talk</strong> is a volunteer-run project that was created at Chi Hack Night, a weekly community event where people of all backgrounds come together to work on civic tech projects.
+  </p>
 </div>
 
-<div class="section-4 vertical-cols -center">
-  <h1> Application to Other Cities </h1>
-  <a href="http://github.com/TransitTalk/Transit-Talk" class="btn btn-github">Visit our Github</a>
-  <p> <b>Transit Talk</b> is built for more than just Chicago. Through the use of GTFS, a universal data standard used by transit agencies around the world, Transit Talk can be implemented elsewhere easily. Visit our “In Your City” tab to learn more.
+<div class="vertical-cols -center">
+  <h2> Application to Other Cities </h2>
+  <a href="http://github.com/TransitTalk/Transit-Talk" class="btn">Visit our Github</a>
+  <p>
+    <strong>Transit Talk</strong> is built for more than just Chicago. Through the use of GTFS, a universal data standard used by transit agencies around the world, Transit Talk can be implemented elsewhere easily. Visit our “In Your City” tab to learn more.
   </p>
 </div>

--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@ title: Transit Talk
   </h1>
 </div>
 
-<div class="bkgd-1 simple-cols -standard">
+<div class="bkgd-1 simple-cols -standard three-btn-cont">
   <h2> Our Tool </h2>
 
   <div class="center-btn">
@@ -21,10 +21,10 @@ title: Transit Talk
   <p class="basic-p">
     <strong>Transit Talk</strong> empowers users to easily submit issue reports for things like cleanliness, accessibility, and delays on public transit, generating real-time, crowdsourced knowledge about a transit system.
   </p>
-</div>
 
-<div class="three-buttons">
-  <img src="/assets/images/features.png" class="features-img dsktp-only">
+  <div class="three-buttons">
+    <img src="/assets/images/features.png" class="features-img dsktp-only">
+  </div>
 </div>
 
 <div class="simple-cols -standard">

--- a/mission.html
+++ b/mission.html
@@ -2,39 +2,29 @@
 title: Our Mission
 ---
 
-<div class="hero-banner">
+<div class="hero-banner vertical-cols -center">
   <h1> Our Mission</h1>
-  <img src="/assets/images/logo.png" style="margin-left: 45%;
-    height: 90px;">
-    <h2>Making Transit Better</h2>
-
-</div>
-<div class="section-1 bkgd-1">
-  <div class="h1-left">
-    <img src="/assets/images/mission-screen-1.png" style="    margin: -70px -160px 0px 0px;height: 260px;">
-  </div>
-  <div class="tool-p-right">
-    <p>Here at <b>Transit Talk</b>, we aim to create a transparent record of the issues riders encounter on their commutes, empowering them to make educated decisions about their commutes while also encouraging transit agencies to become more responsive to the needs of their riders.
-    </p>
-  </div>
+  <img src="/assets/images/logo.png" class="logo-med">
+  <h2>Making Transit Better</h2>
 </div>
 
-<div class="section-2">
- <div class="center-text">
-    <p>As a team of volunteers of varying transit-riding backgrounds, we understand the problems commuters face when using public transit. We aim to make everyone’s commute simpler, and to allow them to make educated choices on each trip. </p>
+<div class="bkgd-1 simple-cols -standard">
+  <img src="/assets/images/mission-screen-1.png" class="mobile-img no-grow">
+  <p>
+    Here at <strong>Transit Talk</strong>, we aim to create a transparent record of the issues riders encounter on their commutes, empowering them to make educated decisions about their commutes while also encouraging transit agencies to become more responsive to the needs of their riders.
+  </p>
 </div>
-<div class="section-3 bkgd-2">
-  <div class="p-left">
-    <p>Transit information should be open and easily accessible. We hope to bridge the gap between transit administrations and their users, and to allow users to have some control over their commutes. <p>
-    
-  </div>
-  <div class="p-right">
-    <img src="/assets/images/mission-screen-2.png" style="margin-top:-54px;height: 260px;">
-  </div>
+
+<div class="simple-cols -standard">
+  <p class="hero-p">
+    As a team of volunteers of varying transit-riding backgrounds, we understand the problems commuters face when using public transit. We aim to make everyone’s commute simpler, and to allow them to make educated choices on each trip.
+  </p>
 </div>
-<div class="section-4">
-  <div class="p-center">  
-    
-  </div>
+
+<div class="bkgd-2 simple-cols -standard">
+  <p class="basic-p">
+    Transit information should be open and easily accessible. We hope to bridge the gap between transit administrations and their users, and to allow users to have some control over their commutes.
+  </p>
+  <img src="/assets/images/mission-screen-2.png" class="mobile-img no-grow">
 </div>
 

--- a/mission.html
+++ b/mission.html
@@ -4,13 +4,14 @@ title: Our Mission
 
 <div class="hero-banner vertical-cols -center">
   <h1> Our Mission</h1>
-  <img src="/assets/images/logo.png" class="logo-med">
+  <img src="/assets/images/logo.png" alt="TransitTalk Logo" class="logo-med">
   <h2>Making Transit Better</h2>
 </div>
 
 <div class="bkgd-1 simple-cols -standard">
-  <img src="/assets/images/mission-screen-1.png" class="mobile-img no-grow">
-  <p>
+  <img src="/assets/images/mission-screen-1.png" class="mobile-img no-grow"
+    alt="TransitTalk Mobile Screenshot">
+  <p class="basic-p">
     Here at <strong>Transit Talk</strong>, we aim to create a transparent record of the issues riders encounter on their commutes, empowering them to make educated decisions about their commutes while also encouraging transit agencies to become more responsive to the needs of their riders.
   </p>
 </div>
@@ -25,6 +26,7 @@ title: Our Mission
   <p class="basic-p">
     Transit information should be open and easily accessible. We hope to bridge the gap between transit administrations and their users, and to allow users to have some control over their commutes.
   </p>
-  <img src="/assets/images/mission-screen-2.png" class="mobile-img no-grow">
+  <img src="/assets/images/mission-screen-2.png" class="mobile-img no-grow"
+    alt="TransitTalk Mobile Screenshot">
 </div>
 

--- a/team.html
+++ b/team.html
@@ -2,21 +2,14 @@
 title: Our Team
 ---
 
-<div class="hero-banner">
+<div class="hero-banner vertical-cols -center">
   <h1> Our Team</h1>
-  <img src="/assets/images/logo.png" style="margin-left: 45%;
-    height: 90px;">
-    <h2></h2>
-
-</div>
-<div class="section-1 bkgd-1">
-  <div class="h1-left">
-    <img src="/assets/images/tool-screen-1.png" style="    margin: -70px -160px 0px 0px;height: 260px;">
-  </div>
-  <div class="tool-p-right">
-    <p><b>Transit Talk</b> was formed out of Chi Hack Night, a weekly meeting of civic tech do-gooders, and was created by an all-volunteer group of computer scientists, transit advocates, and more. 
-    </p>
-  </div>
+  <img src="/assets/images/logo.png" class="logo-med">
 </div>
 
-<div class="section-2">
+<div class="bkgd-1 simple-cols -standard">
+  <img src="/assets/images/tool-screen-1.png" class="mobile-img no-grow">
+  <p class="basic-p">
+    <strong>Transit Talk</strong> was formed out of Chi Hack Night, a weekly meeting of civic tech do-gooders, and was created by an all-volunteer group of computer scientists, transit advocates, and more.
+  </p>
+</div>

--- a/team.html
+++ b/team.html
@@ -4,11 +4,12 @@ title: Our Team
 
 <div class="hero-banner vertical-cols -center">
   <h1> Our Team</h1>
-  <img src="/assets/images/logo.png" class="logo-med">
+  <img src="/assets/images/logo.png" alt="TransitTalk Logo" class="logo-med">
 </div>
 
 <div class="bkgd-1 simple-cols -standard">
-  <img src="/assets/images/tool-screen-1.png" class="mobile-img no-grow">
+  <img src="/assets/images/tool-screen-1.png" class="mobile-img no-grow"
+  	alt="TransitTalk Mobile Screenshot">
   <p class="basic-p">
     <strong>Transit Talk</strong> was formed out of Chi Hack Night, a weekly meeting of civic tech do-gooders, and was created by an all-volunteer group of computer scientists, transit advocates, and more.
   </p>

--- a/tool.html
+++ b/tool.html
@@ -4,11 +4,10 @@ title: Our Tool
 
 <div class="hero-banner">
   <h1> Our Tool</h1>
-  <img src="/assets/images/logo.png" style="margin-left: 45%;
-    height: 90px;">
+  <img src="/assets/images/logo.png" class="logo-med">
     <h2>Rider-Powered Transit Information</h2>
-
 </div>
+
 <div class="section-1 bkgd-1">
   <div class="h1-left">
     <img src="/assets/images/tool-screen-1.png" style="    margin: -70px -160px 0px 0px;height: 260px;">
@@ -26,14 +25,14 @@ title: Our Tool
 <div class="section-3 bkgd-2">
   <div class="p-left">
     <p>Rather than submit information into an administrative black box that other riders cannot view, Transit Talk enables users to openly view all reports made by fellow users on their local public transit system.<p>
-    
+
   </div>
   <div class="p-right">
     <img src="/assets/images/tool-screen-2.png" style="margin-top:-54px;height: 260px;">
   </div>
 </div>
 <div class="section-4">
-  <div class="p-center">  
+  <div class="p-center">
     <p> Users can save stops they frequent and check what’s going on before they head out for the day, understanding which routes (or even specific vehicles) to avoid to make their commute better and simpler.</p>
   </div>
 </div>

--- a/tool.html
+++ b/tool.html
@@ -33,4 +33,3 @@ title: Our Tool
     Users can save stops they frequent and check what’s going on before they head out for the day, understanding which routes (or even specific vehicles) to avoid to make their commute better and simpler.
   </p>
 </div>
-

--- a/tool.html
+++ b/tool.html
@@ -2,38 +2,35 @@
 title: Our Tool
 ---
 
-<div class="hero-banner">
+<div class="hero-banner vertical-cols -center">
   <h1> Our Tool</h1>
   <img src="/assets/images/logo.png" class="logo-med">
-    <h2>Rider-Powered Transit Information</h2>
+  <h2>Rider-Powered Transit Information</h2>
 </div>
 
-<div class="section-1 bkgd-1">
-  <div class="h1-left">
-    <img src="/assets/images/tool-screen-1.png" style="    margin: -70px -160px 0px 0px;height: 260px;">
-  </div>
-  <div class="tool-p-right">
-    <p><b>Transit Talk</b> is a mobile-first web app that empowers transit riders to quickly and easily submit issue reports that generate real-time, crowdsourced knowledge about activity on their local transit system.
-    </p>
-  </div>
+<div class="bkgd-1 simple-cols -standard">
+  <img src="/assets/images/tool-screen-1.png" class="mobile-img no-grow">
+  <p class="basic-p">
+    <strong>Transit Talk</strong> is a mobile-first web app that empowers transit riders to quickly and easily submit issue reports that generate real-time, crowdsourced knowledge about activity on their local transit system.
+  </p>
 </div>
 
-<div class="section-2">
- <div class="center-text">
-    <p><b>Transit Talk</b> allows users to quickly submit issue reports, generating a real time, crowd-sourced map of issues that can ultimately be used by transit advocates, transit agencies, and transit riders. </p>
+<div class="simple-cols -standard">
+  <p class="basic-p">
+    <strong>Transit Talk</strong> allows users to quickly submit issue reports, generating a real time, crowd-sourced map of issues that can ultimately be used by transit advocates, transit agencies, and transit riders.
+  </p>
 </div>
-<div class="section-3 bkgd-2">
-  <div class="p-left">
-    <p>Rather than submit information into an administrative black box that other riders cannot view, Transit Talk enables users to openly view all reports made by fellow users on their local public transit system.<p>
 
-  </div>
-  <div class="p-right">
-    <img src="/assets/images/tool-screen-2.png" style="margin-top:-54px;height: 260px;">
-  </div>
+<div class="bkgd-2 simple-cols -standard">
+  <p class="basic-p">
+    Rather than submit information into an administrative black box that other riders cannot view, Transit Talk enables users to openly view all reports made by fellow users on their local public transit system.
+  </p>
+  <img src="/assets/images/tool-screen-2.png" class="mobile-img no-grow">
 </div>
-<div class="section-4">
-  <div class="p-center">
-    <p> Users can save stops they frequent and check what’s going on before they head out for the day, understanding which routes (or even specific vehicles) to avoid to make their commute better and simpler.</p>
-  </div>
+
+<div class="simple-cols -standard">
+  <p class="basic-p">
+    Users can save stops they frequent and check what’s going on before they head out for the day, understanding which routes (or even specific vehicles) to avoid to make their commute better and simpler.
+  </p>
 </div>
 

--- a/tool.html
+++ b/tool.html
@@ -4,7 +4,7 @@ title: Our Tool
 
 <div class="hero-banner vertical-cols -center">
   <h1> Our Tool</h1>
-  <img src="/assets/images/logo.png" class="logo-med">
+  <img src="/assets/images/logo.png" alt="TransitTalk Logo" class="logo-med">
   <h2>Rider-Powered Transit Information</h2>
 </div>
 
@@ -25,7 +25,8 @@ title: Our Tool
   <p class="basic-p">
     Rather than submit information into an administrative black box that other riders cannot view, Transit Talk enables users to openly view all reports made by fellow users on their local public transit system.
   </p>
-  <img src="/assets/images/tool-screen-2.png" class="mobile-img no-grow">
+  <img src="/assets/images/tool-screen-2.png" class="mobile-img no-grow"
+    alt="TransitTalk Mobile Screenshot">
 </div>
 
 <div class="simple-cols -standard">


### PR DESCRIPTION
## Description

In this PR I made the whole website responsive using flexbox, and added a bunch of new helper classes to make development simpler and cleaner. Here's a comparison screenshot of the homepage on mobile:

| Before | After |
| --- | --- |
| ![Screenshot from 2019-09-01 16-51-25](https://user-images.githubusercontent.com/3187531/64082706-d3cde880-ccd8-11e9-9fc8-19a5a2f1a289.png) | ![Screenshot from 2019-09-01 16-51-16](https://user-images.githubusercontent.com/3187531/64082707-d3cde880-ccd8-11e9-87b1-621287bad13a.png) |

Some of the styling isn't perfect, but this improves readability and makes the site overall look decent.

I also improved accessibility by fixing heading levels (only one `<h1>` per page, then followed by `<h2>` elements), and by adding `alt` attributes to images. See this [great WebAIM article](https://webaim.org/techniques/alttext/) about alt tags. I also fixed `<button>` elements being used for links, which should always be done with an `<a>` element.

@shrubin2 - I tagged you to review this so you can see some of my methods and see some of my changes. Hopefully this makes sense and lines up with our in person discussion.